### PR TITLE
This commit adds functionality that will allow for a new strategy to be a

### DIFF
--- a/doc/pyapi.rst
+++ b/doc/pyapi.rst
@@ -420,6 +420,13 @@ API documentation
       Returns strategy number ``i``.  Strategies are numbered
       starting with ``0``.
 
+   .. py:method:: add_strategy([label=""])
+
+      Add a :py:class:`gambit.Strategy` to the player's list of strategies.
+      This method is only applicable to games in a strategic form. When
+      this method is applied to a player in an extensive form it will raise
+      a type error.
+
 .. py:class:: Strategy
 
    Represents a strategy available to a :py:class:`gambit.Player`.

--- a/src/python/gambit/lib/libgambit.pyx
+++ b/src/python/gambit/lib/libgambit.pyx
@@ -89,6 +89,7 @@ cdef extern from "libgambit/game.h":
 
         int NumInfosets()
         c_GameInfoset GetInfoset(int) except +IndexError
+        c_GameStrategy NewStrategy()
 
     ctypedef struct c_GameOutcomeRep "GameOutcomeRep":
         c_Game GetGame()

--- a/src/python/gambit/lib/player.pxi
+++ b/src/python/gambit/lib/player.pxi
@@ -12,6 +12,19 @@ cdef class Infosets(Collection):
 cdef class Strategies(Collection):
     "Represents a collection of strategies for a player."
     cdef c_GamePlayer player
+
+    def add(self, label=""):
+        cdef Game g
+        g = Game()
+        g.game = self.player.deref().GetGame()
+        if g.is_tree:
+            raise TypeError, "Adding strategies is only applicable to games in strategic form"
+        cdef Strategy s
+        s = Strategy()
+        s.strategy = self.player.deref().NewStrategy()
+        s.label = str(label)
+        return s
+
     def __len__(self):    return self.player.deref().NumStrategies()
     def __getitem__(self, st):
         if not isinstance(st, int):  return Collection.__getitem__(self, st)
@@ -19,6 +32,7 @@ cdef class Strategies(Collection):
         s = Strategy()
         s.strategy = self.player.deref().GetStrategy(st+1)
         return s
+    
 
 cdef class Player:
     cdef c_GamePlayer player
@@ -78,7 +92,7 @@ cdef class Player:
             s = Strategies()
             s.player = self.player
             return s
-
+        
     property infosets:
         def __get__(self):
             cdef Infosets s

--- a/src/python/gambit/tests/test_players.py
+++ b/src/python/gambit/tests/test_players.py
@@ -4,55 +4,71 @@ from nose.tools import assert_raises
 
 class TestGambitPlayers(object):
     def setUp(self):
-        self.game = gambit.new_table([2,2])
-        self.game.players[0].label = "Alphonse"
-        self.game.players[1].label = "Gaston"
+        self.strategic_game = gambit.new_table([2,2])
+        self.strategic_game.players[0].label = "Alphonse"
+        self.strategic_game.players[1].label = "Gaston"
+        self.extensive_game = gambit.new_tree()
     
     def tearDown(self):
-        del self.game
+        del self.strategic_game
         
     def test_initial_player_count(self):
         "Test to ensure 0 initial players"
-        assert len(self.game.players) == 2
+        assert len(self.strategic_game.players) == 2
         
     def test_game_add_players(self):
         "Test to add player"
-        p1 = self.game.players[0]
+        p1 = self.strategic_game.players[0]
         assert p1.label == "Alphonse"
-        p2 = self.game.players[1]
+        p2 = self.strategic_game.players[1]
         assert p2.label == "Gaston"
 
     def test_game_add_duplicate_player_names(self):
         "Test to add player with preexisting name"
         with warnings.catch_warnings(True) as w:
-                self.game.players[1].label = "Alphonse"
+                self.strategic_game.players[1].label = "Alphonse"
                 assert str(w[0].message) == "Another player with an identical label exists"
-        p1 = self.game.players[0]
+        p1 = self.strategic_game.players[0]
         assert p1.label == "Alphonse"
-        p2 = self.game.players[1]
+        p2 = self.strategic_game.players[1]
         assert p2.label == "Alphonse"
 
     def test_game_players_index_by_string(self):
         "Test find a player by providing a label"
-        p1 = self.game.players["Alphonse"]
+        p1 = self.strategic_game.players["Alphonse"]
         assert p1.label == "Alphonse"
-        p2 = self.game.players["Gaston"]
+        p2 = self.strategic_game.players["Gaston"]
         assert p2.label == "Gaston"
 
     def test_game_players_index_exception_int(self):
         "Test to verify when an index is out of range"
-        assert_raises(IndexError, self.game.players.__getitem__, 3)
+        assert_raises(IndexError, self.strategic_game.players.__getitem__, 3)
 
     def test_game_players_index_exception_string(self):
         "Test to verify when a player label is not in the list of players"
-        assert_raises(IndexError, self.game.players.__getitem__, "None")
+        assert_raises(IndexError, self.strategic_game.players.__getitem__, "None")
 
     def test_game_players_index_exception_player(self):
         "Test to verify when a player object is not in the players"
         self.game_2 = gambit.new_table([2,2])
-        assert_raises(IndexError, self.game.players.__getitem__, self.game_2.players[0])
+        assert_raises(IndexError, self.strategic_game.players.__getitem__, self.game_2.players[0])
 
     def test_game_players_index_exception_player(self):
         "Test to verify when attempting to retrieve with invalid input"
-        assert_raises(TypeError, self.game.players.__getitem__, 1.3)
+        assert_raises(TypeError, self.strategic_game.players.__getitem__, 1.3)
 
+    def test_game_add_strategies_to_player_strategic_game(self):
+        "Test to add a strategy to a player in a strategic game"
+        assert len(self.strategic_game.players[0].strategies) == 2
+        self.strategic_game.players[0].strategies.add("1st new strategy")
+        assert len(self.strategic_game.players[0].strategies) == 3
+
+        with warnings.catch_warnings(True) as w:
+            self.strategic_game.players[0].strategies.add("1st new strategy")
+            assert str(w[0].message) == "This player has another strategy with an identical label"
+        assert len(self.strategic_game.players[0].strategies) == 4
+
+    def test_game_add_strategies_to_player_extensive_game(self):
+        "Test to ensure that an exception is raised when attempting to add a strategy to a player in an extensive game"
+        self.extensive_game.players.add("Alice")
+        assert_raises(TypeError, self.extensive_game.players[0].strategies.add, "Test")


### PR DESCRIPTION
This commit adds functionality that will allow for a new strategy to be added to a player's set of strategies.

The add_strategy functionality is intended for use with games in strategic form. If it is applied to a game in extensive form it will raise a TypeError.

Additional changes have been made to the testing suite to verify the new functionality. Also, the player object documentation has been updated to reflect the new method.
